### PR TITLE
fix: agg_proof_mode to take input instead of hardcoded value

### DIFF
--- a/proposer/succinct/bin/server.rs
+++ b/proposer/succinct/bin/server.rs
@@ -194,7 +194,7 @@ async fn request_span_proof(
     let proof_id = state
         .network_prover
         .prove(&state.range_pk, &sp1_stdin)
-        .compressed()
+        .mode(state.agg_proof_mode)
         .strategy(state.range_proof_strategy)
         .skip_simulation(true)
         .cycle_limit(1_000_000_000_000)


### PR DESCRIPTION
Currently, all proofs in `SPAN` mode have compressed agg_proof_mode. This should be configurable with `AGG_PROOF_MODE` env variable