### PR TITLE
build: move zkvm ELFs into a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4122,6 +4122,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "op-succinct-elfs"
+version = "0.1.0"
+
+[[package]]
 name = "op-succinct-fees"
 version = "0.1.0"
 dependencies = [
@@ -4205,6 +4209,7 @@ dependencies = [
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
  "op-succinct-client-utils",
+ "op-succinct-elfs",
  "reqwest",
  "revm",
  "rkyv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ kona-genesis = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.
 # op-succinct
 op-succinct-prove = { path = "scripts/prove" }
 op-succinct-client-utils = { path = "utils/client" }
+op-succinct-elfs = { path = "utils/elfs" }
 op-succinct-host-utils = { path = "utils/host" }
 op-succinct-build-utils = { path = "utils/build" }
 op-succinct-proposer = { path = "proposer/succinct" }

--- a/utils/elfs/Cargo.toml
+++ b/utils/elfs/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "op-succinct-elfs"
+version = "0.1.0"
+license.workspace = true
+edition.workspace = true

--- a/utils/elfs/src/lib.rs
+++ b/utils/elfs/src/lib.rs
@@ -1,0 +1,4 @@
+//! The zkvm ELF binaries.
+
+pub const AGG_ELF: &[u8] = include_bytes!("../../../elf/aggregation-elf");
+pub const RANGE_ELF: &[u8] = include_bytes!("../../../elf/range-elf");

--- a/utils/host/Cargo.toml
+++ b/utils/host/Cargo.toml
@@ -11,6 +11,7 @@ sp1-sdk.workspace = true
 
 # local
 op-succinct-client-utils.workspace = true
+op-succinct-elfs.workspace = true
 
 # op-alloy
 op-alloy-rpc-types.workspace = true


### PR DESCRIPTION
Rationale:

* To get access to these ELFs on the agglayer provers side without heavy dependencies.

