### PR TITLE
feat: enhance logging configuration and add logger test example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7063,7 +7063,6 @@ version = "0.1.0"
 dependencies = [
  "cargo_metadata",
  "sp1-build",
- "sp1-build",
 ]
 
 [[package]]
@@ -10095,7 +10094,6 @@ checksum = "b6f03537814ef0b91ca4c45d777e8d584cf4d401bb03fe384b7baae1d14e7707"
 dependencies = [
  "bincode",
  "ctrlc",
- "once_cell",
  "prost",
  "serde",
  "sp1-core-machine",
@@ -11471,6 +11469,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11490,12 +11498,14 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ bincode = "1.3.3"
 base64 = "0.22.1"
 tower-http = { version = "0.5.2", features = ["limit"] }
 tracing = { version = "0.1.40", default-features = false }
-tracing-subscriber = { version = "0.3.18", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.18", features = ["fmt", "json"] }
 metrics = "0.24.1"
 metrics-exporter-prometheus = "0.16.2"
 metrics-process = "2.4.0"

--- a/validity/Cargo.toml
+++ b/validity/Cargo.toml
@@ -11,6 +11,10 @@ homepage.workspace = true
 name = "validity"
 path = "bin/validity.rs"
 
+[[example]]
+name = "logger_test"
+path = "examples/logger_test.rs"
+
 [dependencies]
 
 # workspace

--- a/validity/bin/validity.rs
+++ b/validity/bin/validity.rs
@@ -6,7 +6,7 @@ use op_succinct_host_utils::{
 };
 use op_succinct_proof_utils::initialize_host;
 use op_succinct_validity::{
-    read_proposer_env, setup_proposer_logger, DriverDBClient, Proposer, RequesterConfig,
+    read_proposer_env, setup_logger_with_format, DriverDBClient, Proposer, RequesterConfig,
     ValidityGauge,
 };
 use std::sync::Arc;
@@ -37,12 +37,13 @@ async fn main() -> Result<()> {
 
     dotenv::from_filename(args.env_file).ok();
 
-    setup_proposer_logger();
+    // Read the environment variables first to get the log format
+    let env_config = read_proposer_env()?;
+
+    // Setup logger with the configured format
+    setup_logger_with_format(&env_config.log_format);
 
     let fetcher = OPSuccinctDataFetcher::new_with_rollup_config().await?;
-
-    // Read the environment variables.
-    let env_config = read_proposer_env()?;
 
     let db_client = Arc::new(DriverDBClient::new(&env_config.db_url).await?);
     let proposer_config = RequesterConfig {

--- a/validity/examples/logger_test.rs
+++ b/validity/examples/logger_test.rs
@@ -1,0 +1,47 @@
+/// Simple test program to verify LOG_FORMAT configuration works
+use op_succinct_validity::setup_logger_with_format;
+use std::env;
+use tracing::{info, warn, error};
+
+fn main() {
+    // Read LOG_FORMAT from environment variable, default to "pretty"
+    let log_format = env::var("LOG_FORMAT").unwrap_or_else(|_| "pretty".to_string());
+    
+    println!("Testing LOG_FORMAT configuration...");
+    println!("LOG_FORMAT environment variable: {}", log_format);
+    
+    // Initialize logger with the format from environment
+    println!("\n=== Initializing logger with format: '{}' ===", log_format);
+    setup_logger_with_format(&log_format);
+    
+    // Test different log levels
+    info!("This is an info message");
+    warn!("This is a warning message");
+    error!("This is an error message");
+    
+    // Test structured logging
+    info!(
+        user_id = 12345,
+        action = "login",
+        ip_address = "192.168.1.1",
+        "User login event"
+    );
+    
+    warn!(
+        error_code = "E001",
+        retry_count = 3,
+        "Retrying failed operation"
+    );
+    
+    error!(
+        exception = "NullPointerException",
+        stack_trace = "at main.rs:42",
+        "Critical error occurred"
+    );
+    
+    println!("\nLogger test completed. Log output above shows format: '{}'", log_format);
+    println!("\nTo test different formats:");
+    println!("  LOG_FORMAT=pretty cargo run --example logger_test");
+    println!("  LOG_FORMAT=json cargo run --example logger_test");
+    println!("  LOG_FORMAT=invalid cargo run --example logger_test  # should default to pretty");
+}

--- a/validity/examples/logger_test.rs
+++ b/validity/examples/logger_test.rs
@@ -1,44 +1,35 @@
 /// Simple test program to verify LOG_FORMAT configuration works
 use op_succinct_validity::setup_logger_with_format;
 use std::env;
-use tracing::{info, warn, error};
+use tracing::{error, info, warn};
 
 fn main() {
     // Read LOG_FORMAT from environment variable, default to "pretty"
     let log_format = env::var("LOG_FORMAT").unwrap_or_else(|_| "pretty".to_string());
-    
+
     println!("Testing LOG_FORMAT configuration...");
     println!("LOG_FORMAT environment variable: {}", log_format);
-    
+
     // Initialize logger with the format from environment
     println!("\n=== Initializing logger with format: '{}' ===", log_format);
     setup_logger_with_format(&log_format);
-    
+
     // Test different log levels
     info!("This is an info message");
     warn!("This is a warning message");
     error!("This is an error message");
-    
+
     // Test structured logging
-    info!(
-        user_id = 12345,
-        action = "login",
-        ip_address = "192.168.1.1",
-        "User login event"
-    );
-    
-    warn!(
-        error_code = "E001",
-        retry_count = 3,
-        "Retrying failed operation"
-    );
-    
+    info!(user_id = 12345, action = "login", ip_address = "192.168.1.1", "User login event");
+
+    warn!(error_code = "E001", retry_count = 3, "Retrying failed operation");
+
     error!(
         exception = "NullPointerException",
         stack_trace = "at main.rs:42",
         "Critical error occurred"
     );
-    
+
     println!("\nLogger test completed. Log output above shows format: '{}'", log_format);
     println!("\nTo test different formats:");
     println!("  LOG_FORMAT=pretty cargo run --example logger_test");

--- a/validity/src/env.rs
+++ b/validity/src/env.rs
@@ -28,6 +28,7 @@ pub struct EnvironmentConfig {
     pub agglayer: bool,
     pub safe_db_fallback: bool,
     pub grpc_addr: String,
+    pub log_format: String,
 }
 
 /// Helper function to get environment variables with a default value and parse them.
@@ -121,6 +122,7 @@ pub fn read_proposer_env() -> Result<EnvironmentConfig> {
         safe_db_fallback: get_env_var("SAFE_DB_FALLBACK", Some(false))?,
         agglayer: get_env_var("AGGLAYER", Some(false))?,
         grpc_addr: get_env_var("GRPC_ADDRESS", Some("[::1]:50051".to_string()))?,
+        log_format: get_env_var("LOG_FORMAT", Some("pretty".to_string()))?,
     };
 
     Ok(config)

--- a/validity/src/logger.rs
+++ b/validity/src/logger.rs
@@ -27,10 +27,7 @@ pub fn setup_logger_with_format(format: &str) {
     match format.to_lowercase().as_str() {
         "json" => {
             // Initialize with JSON formatting
-            tracing_subscriber::fmt()
-                .with_env_filter(env_filter)
-                .json()
-                .init();
+            tracing_subscriber::fmt().with_env_filter(env_filter).json().init();
         }
         "pretty" | _ => {
             // Default to pretty formatting with ANSI colors

--- a/validity/src/logger.rs
+++ b/validity/src/logger.rs
@@ -1,36 +1,52 @@
 /// Set up the logger for the proposer.
 pub fn setup_proposer_logger() {
-    // Set up logging using the provided format
-    let format = tracing_subscriber::fmt::format()
-        .with_level(true)
-        .with_target(false)
-        .with_thread_ids(false)
-        .with_thread_names(false)
-        .with_file(false)
-        .with_line_number(false)
-        .with_ansi(true);
+    setup_logger_with_format("pretty");
+}
 
+/// Set up the logger with a specific format.
+pub fn setup_logger_with_format(format: &str) {
     // Turn off all logging from kona and SP1.
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive("single_hint_handler=error".parse().unwrap())
-                .add_directive("execute=error".parse().unwrap())
-                .add_directive("sp1_prover=error".parse().unwrap())
-                .add_directive("boot_loader=error".parse().unwrap())
-                .add_directive("client_executor=error".parse().unwrap())
-                .add_directive("client=error".parse().unwrap())
-                .add_directive("channel_assembler=error".parse().unwrap())
-                .add_directive("attributes_queue=error".parse().unwrap())
-                .add_directive("batch_validator=error".parse().unwrap())
-                .add_directive("batch_queue=error".parse().unwrap())
-                .add_directive("client_derivation_driver=error".parse().unwrap())
-                .add_directive("block_builder=error".parse().unwrap())
-                .add_directive("host_server=error".parse().unwrap())
-                .add_directive("kona_protocol=error".parse().unwrap())
-                .add_directive("sp1_core_executor=off".parse().unwrap())
-                .add_directive("sp1_core_machine=error".parse().unwrap()),
-        )
-        .event_format(format)
-        .init();
+    let env_filter = tracing_subscriber::EnvFilter::from_default_env()
+        .add_directive("single_hint_handler=error".parse().unwrap())
+        .add_directive("execute=error".parse().unwrap())
+        .add_directive("sp1_prover=error".parse().unwrap())
+        .add_directive("boot_loader=error".parse().unwrap())
+        .add_directive("client_executor=error".parse().unwrap())
+        .add_directive("client=error".parse().unwrap())
+        .add_directive("channel_assembler=error".parse().unwrap())
+        .add_directive("attributes_queue=error".parse().unwrap())
+        .add_directive("batch_validator=error".parse().unwrap())
+        .add_directive("batch_queue=error".parse().unwrap())
+        .add_directive("client_derivation_driver=error".parse().unwrap())
+        .add_directive("block_builder=error".parse().unwrap())
+        .add_directive("host_server=error".parse().unwrap())
+        .add_directive("kona_protocol=error".parse().unwrap())
+        .add_directive("sp1_core_executor=off".parse().unwrap())
+        .add_directive("sp1_core_machine=error".parse().unwrap());
+
+    match format.to_lowercase().as_str() {
+        "json" => {
+            // Initialize with JSON formatting
+            tracing_subscriber::fmt()
+                .with_env_filter(env_filter)
+                .json()
+                .init();
+        }
+        "pretty" | _ => {
+            // Default to pretty formatting with ANSI colors
+            let pretty_format = tracing_subscriber::fmt::format()
+                .with_level(true)
+                .with_target(false)
+                .with_thread_ids(false)
+                .with_thread_names(false)
+                .with_file(false)
+                .with_line_number(false)
+                .with_ansi(true);
+
+            tracing_subscriber::fmt()
+                .with_env_filter(env_filter)
+                .event_format(pretty_format)
+                .init();
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces support for configurable logging formats in the `validity` module, with enhancements to environment configuration, logging setup, and testing. The most notable changes include adding a `LOG_FORMAT` environment variable, implementing a logging format selector, and creating an example program to test logging configurations.

### Logging Enhancements:
* Added support for JSON logging format by modifying the `tracing-subscriber` dependency to include the `json` feature in `Cargo.toml`.
* Updated `validity/src/logger.rs` to implement `setup_logger_with_format`, allowing dynamic selection between "pretty" and "json" formats based on the `LOG_FORMAT` environment variable. [[1]](diffhunk://#diff-c62ac19a3ff8100cd19e8597614684d54675e7aec4416ae092dbe6a932f36a35L3-R9) [[2]](diffhunk://#diff-c62ac19a3ff8100cd19e8597614684d54675e7aec4416ae092dbe6a932f36a35L32-R52)

### Environment Configuration:
* Added a new `log_format` field to the `EnvironmentConfig` struct in `validity/src/env.rs`.
* Updated the `read_proposer_env` function to read the `LOG_FORMAT` environment variable, defaulting to "pretty" if not set.

### Testing and Examples:
* Added a new example program, `logger_test.rs`, to verify the functionality of different logging formats. This program demonstrates structured logging and provides instructions for testing various formats.
* Registered the `logger_test` example in `validity/Cargo.toml`.