### PR TITLE
feat: add debug logging to proofs service

### DIFF
--- a/validity/src/db/types.rs
+++ b/validity/src/db/types.rs
@@ -75,7 +75,7 @@ impl From<i16> for RequestMode {
     }
 }
 
-#[derive(FromRow, Default, Clone)]
+#[derive(FromRow, Default, Clone, Debug)]
 pub struct OPSuccinctRequest {
     pub id: i64,
     pub status: RequestStatus,


### PR DESCRIPTION
This pull request introduces enhanced debugging capabilities in the `validity` module by adding `Debug` trait derivations and new debug logging statements. These changes aim to improve traceability and observability during the processing of requests and proofs.

### Debugging Enhancements:

* [`validity/src/db/types.rs`](diffhunk://#diff-521288304df58474c64f4e310dbdb8ebd3c8405b800f6dc38a69023cf4b3adc4L78-R78): Added the `Debug` trait to the `OPSuccinctRequest` struct to enable detailed logging of its instances.
* [`validity/src/proofs_service.rs`](diffhunk://#diff-c798629bafaa232f99d4d598cfa95024714c8b26d7815e0b677f7f4582be2731L5-R6): Included `debug` in the `tracing` module imports and added `tracing_subscriber::field::debug` for structured logging.
* [`validity/src/proofs_service.rs`](diffhunk://#diff-c798629bafaa232f99d4d598cfa95024714c8b26d7815e0b677f7f4582be2731R83-R87): Added a debug log to trace the `AggProofRequest` processing, logging the request details.
* [`validity/src/proofs_service.rs`](diffhunk://#diff-c798629bafaa232f99d4d598cfa95024714c8b26d7815e0b677f7f4582be2731R119-R129): Introduced a debug log to capture detailed information about fetched range proofs, including blocks, commitments, and chain IDs.