### PR TITLE
feat: validate aggproof requests for dups and gaps

### DIFF
--- a/scripts/utils/bin/fetch_rollup_config.rs
+++ b/scripts/utils/bin/fetch_rollup_config.rs
@@ -187,10 +187,7 @@ async fn main() -> Result<()> {
         let env_path = current_dir.join(&args.env_file);
         dotenv::from_path(env_path).ok();
     } else {
-        eprintln!(
-            "Warning: Could not determine current directory. {} file not loaded.",
-            args.env_file
-        );
+        eprintln!("Warning: Could not determine current directory. {} file not loaded.", args.env_file);
     }
 
     let output_dir = PathBuf::from(&args.output_dir);

--- a/scripts/utils/bin/fetch_rollup_config.rs
+++ b/scripts/utils/bin/fetch_rollup_config.rs
@@ -187,7 +187,10 @@ async fn main() -> Result<()> {
         let env_path = current_dir.join(&args.env_file);
         dotenv::from_path(env_path).ok();
     } else {
-        eprintln!("Warning: Could not determine current directory. {} file not loaded.", args.env_file);
+        eprintln!(
+            "Warning: Could not determine current directory. {} file not loaded.",
+            args.env_file
+        );
     }
 
     let output_dir = PathBuf::from(&args.output_dir);

--- a/validity/src/env.rs
+++ b/validity/src/env.rs
@@ -1,11 +1,11 @@
 use std::env;
 
 use alloy_primitives::Address;
+use alloy_signer_local::PrivateKeySigner;
 use anyhow::Result;
 use op_succinct_signer_utils::Signer;
 use reqwest::Url;
 use sp1_sdk::{network::FulfillmentStrategy, SP1ProofMode};
-use alloy_signer_local::PrivateKeySigner;
 
 #[derive(Debug, Clone)]
 pub struct EnvironmentConfig {
@@ -89,15 +89,13 @@ pub fn read_proposer_env() -> Result<EnvironmentConfig> {
     };
 
     // Parse proof mode
-    let agg_proof_mode = match get_env_var("AGG_PROOF_MODE", Some("groth16".to_string()))?
-        .to_lowercase()
-        .as_str()
-    {
-        "plonk" => SP1ProofMode::Plonk,
-        "groth16" => SP1ProofMode::Groth16,
-        "compressed" => SP1ProofMode::Compressed,
-        _ => SP1ProofMode::Groth16, // Default to Groth16 if no match
-    };
+    let agg_proof_mode =
+        match get_env_var("AGG_PROOF_MODE", Some("groth16".to_string()))?.to_lowercase().as_str() {
+            "plonk" => SP1ProofMode::Plonk,
+            "groth16" => SP1ProofMode::Groth16,
+            "compressed" => SP1ProofMode::Compressed,
+            _ => SP1ProofMode::Groth16, // Default to Groth16 if no match
+        };
 
     // Optional loop interval
     let loop_interval = get_env_var("LOOP_INTERVAL", Some(DEFAULT_LOOP_INTERVAL))?;

--- a/validity/src/env.rs
+++ b/validity/src/env.rs
@@ -1,11 +1,11 @@
 use std::env;
 
 use alloy_primitives::Address;
-use alloy_signer_local::PrivateKeySigner;
 use anyhow::Result;
 use op_succinct_signer_utils::Signer;
 use reqwest::Url;
 use sp1_sdk::{network::FulfillmentStrategy, SP1ProofMode};
+use alloy_signer_local::PrivateKeySigner;
 
 #[derive(Debug, Clone)]
 pub struct EnvironmentConfig {
@@ -89,13 +89,15 @@ pub fn read_proposer_env() -> Result<EnvironmentConfig> {
     };
 
     // Parse proof mode
-    let agg_proof_mode =
-        match get_env_var("AGG_PROOF_MODE", Some("groth16".to_string()))?.to_lowercase().as_str() {
-            "plonk" => SP1ProofMode::Plonk,
-            "groth16" => SP1ProofMode::Groth16,
-            "compressed" => SP1ProofMode::Compressed,
-            _ => SP1ProofMode::Groth16, // Default to Groth16 if no match
-        };
+    let agg_proof_mode = match get_env_var("AGG_PROOF_MODE", Some("groth16".to_string()))?
+        .to_lowercase()
+        .as_str()
+    {
+        "plonk" => SP1ProofMode::Plonk,
+        "groth16" => SP1ProofMode::Groth16,
+        "compressed" => SP1ProofMode::Compressed,
+        _ => SP1ProofMode::Groth16, // Default to Groth16 if no match
+    };
 
     // Optional loop interval
     let loop_interval = get_env_var("LOOP_INTERVAL", Some(DEFAULT_LOOP_INTERVAL))?;

--- a/validity/src/proof_requester.rs
+++ b/validity/src/proof_requester.rs
@@ -312,7 +312,7 @@ impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
             let curr_proof = &range_proofs[i];
 
             // Check for gap
-            if prev_proof.end_block + 1 != curr_proof.start_block {
+            if prev_proof.end_block != curr_proof.start_block {
                 debug!(
                     "Gap detected: proof {} ends at {} but proof {} starts at {}",
                     i - 1,
@@ -324,7 +324,7 @@ impl<H: OPSuccinctHost> OPSuccinctProofRequester<H> {
             }
 
             // Check for overlap (duplicate blocks)
-            if prev_proof.end_block >= curr_proof.start_block {
+            if prev_proof.end_block > curr_proof.start_block {
                 debug!(
                     "Overlap detected: proof {} ends at {} but proof {} starts at {}",
                     i - 1,

--- a/validity/src/proofs_service.rs
+++ b/validity/src/proofs_service.rs
@@ -1,20 +1,17 @@
-use alloy_primitives::hex::FromHex;
-use alloy_primitives::FixedBytes;
+use alloy_primitives::{hex::FromHex, FixedBytes};
 use bincode::Options;
 use tonic::{Code, Request, Response, Status};
-use tracing::debug;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
-use crate::proof_requester::OPSuccinctProofRequester;
-use crate::OPSuccinctRequest;
-use crate::ProgramConfig;
-use crate::RequestMode;
-use crate::RequesterConfig;
-use crate::ValidityGauge;
-use op_succinct_grpc::proofs::proofs_server::Proofs;
-use op_succinct_grpc::proofs::{AggProofRequest, AggProofResponse, GetMockProofRequest, GetMockProofResponse};
-use op_succinct_host_utils::host::OPSuccinctHost;
-use op_succinct_host_utils::metrics::MetricsGauge;
+use crate::{
+    proof_requester::OPSuccinctProofRequester, OPSuccinctRequest, ProgramConfig, RequestMode,
+    RequesterConfig, ValidityGauge,
+};
+use op_succinct_grpc::proofs::{
+    proofs_server::Proofs, AggProofRequest, AggProofResponse, GetMockProofRequest,
+    GetMockProofResponse,
+};
+use op_succinct_host_utils::{host::OPSuccinctHost, metrics::MetricsGauge};
 use std::{sync::Arc, time::Instant};
 
 pub struct Service<H>
@@ -35,11 +32,7 @@ where
         program_config: ProgramConfig,
         requester_config: RequesterConfig,
     ) -> Self {
-        Self {
-            proof_requester,
-            program_config,
-            requester_config,
-        }
+        Self { proof_requester, program_config, requester_config }
     }
 
     // Limit the L1 block number to the safe head if it is greater than the requested end block
@@ -112,31 +105,37 @@ where
             .unwrap();
 
         // Error in case there's no range proofs
-        if range_proofs.is_empty() {
-            warn!(
-                last_proven_block = req.last_proven_block,
-                requested_end_block = l1_limited_end_block,
-                commitments = ?self.program_config.commitments,
-                l1_chain_id = self.requester_config.l1_chain_id,
-                l2_chain_id = self.requester_config.l2_chain_id,
-                "No consecutive span proof range found for request"
-            );
-            return Err(Status::new(
-                Code::NotFound,
-                "No consecutive span proof range found",
-            ));
-        }
+        // Validate the aggregation proof request
+        match self.proof_requester.validate_aggregation_request(&range_proofs, &req).await {
+            Ok(true) => {
+                debug!(
+                    "Aggregation request validated successfully: start_block={}, end_block={}",
+                    range_proofs.first().unwrap().start_block,
+                    range_proofs.last().unwrap().end_block
+                );
+            }
+            Ok(false) => {
+                warn!(
+                    "Aggregation request validation failed: start_block={}, end_block={}",
+                    range_proofs.first().unwrap().start_block,
+                    range_proofs.last().unwrap().end_block
+                );
+                return Err(Status::new(
+                    Code::InvalidArgument,
+                    "Aggregation request validation failed",
+                ));
+            }
+            Err(e) => {
+                warn!("Error validating aggregation request: {:?}", e);
+            }
+        };
 
         // Set the requested_end_block to the last block from the range proofs
         let end_block = range_proofs.last().unwrap().end_block;
 
         // Prepare the request and query the proof requester
         let op_request = OPSuccinctRequest::new_agg_request(
-            if self.requester_config.mock {
-                RequestMode::Mock
-            } else {
-                RequestMode::Real
-            },
+            if self.requester_config.mock { RequestMode::Mock } else { RequestMode::Real },
             req.last_proven_block as i64,
             end_block,
             self.program_config.commitments.range_vkey_commitment,
@@ -150,27 +149,6 @@ where
             })?,
             self.requester_config.prover_address,
         );
-
-        // Validate the aggregation proof request
-        match self.proof_requester.validate_aggregation_request(&op_request).await {
-            Ok(true) => {
-                debug!(
-                    "Aggregation request validated successfully: start_block={}, end_block={}",
-                    op_request.start_block, op_request.end_block
-                );
-            }
-            Ok(false) => {
-                debug!(
-                    "Aggregation request validation failed, moving to range proofs: start_block={}, end_block={}",
-                    op_request.start_block, op_request.end_block
-                );
-                // Validation failed, continue to try fetching range proofs
-            }
-            Err(e) => {
-                warn!("Error validating aggregation request: {:?}. Moving to range proofs.", e);
-                // Error during validation, continue to try fetching range proofs
-            }
-        };
 
         info!(
             request_type = ?op_request.req_type,
@@ -207,11 +185,10 @@ where
 
         let reply: AggProofResponse;
         if self.proof_requester.mock {
-            let proof = self
-                .proof_requester
-                .generate_mock_agg_proof(&op_request, stdin)
-                .await
-                .map_err(|e| Status::internal(format!("Failed to generate mock proof: {}", e)))?;
+            let proof =
+                self.proof_requester.generate_mock_agg_proof(&op_request, stdin).await.map_err(
+                    |e| Status::internal(format!("Failed to generate mock proof: {}", e)),
+                )?;
 
             // If it's a compressed proof, we need to serialize the entire struct with bincode.
             let proof_bytes = bincode::DefaultOptions::new()
@@ -226,13 +203,12 @@ where
                 ..op_request.clone()
             };
 
-            // Create an aggregation proof request to cover the range with the checkpointed L1 block hash.
-            let last_id = self
-                .proof_requester
-                .db_client
-                .insert_request(&proved_op_request)
-                .await
-                .map_err(|e| Status::internal(format!("Failed to save request to DB: {}", e)))?;
+            // Create an aggregation proof request to cover the range with the checkpointed L1 block
+            // hash.
+            let last_id =
+                self.proof_requester.db_client.insert_request(&proved_op_request).await.map_err(
+                    |e| Status::internal(format!("Failed to save request to DB: {}", e)),
+                )?;
 
             if last_id > 0 {
                 // Convert the last ID to FixedBytes32
@@ -247,9 +223,7 @@ where
                     proof_request_id: alloy_primitives::Bytes::from(last_id).into(),
                 };
             } else {
-                return Err(Status::internal(
-                    "No AGG proof request inserted in the Database",
-                ));
+                return Err(Status::internal("No AGG proof request inserted in the Database"));
             }
         } else {
             let proof_id = self
@@ -284,9 +258,7 @@ where
             .map_err(|e| Status::not_found(format!("Mock proof not found: {}", e)))?;
 
         // Return the mock proof in the response
-        let response = GetMockProofResponse {
-            proof: mock_proof.into(),
-        };
+        let response = GetMockProofResponse { proof: mock_proof.into() };
 
         Ok(Response::new(response))
     }

--- a/validity/src/proofs_service.rs
+++ b/validity/src/proofs_service.rs
@@ -127,6 +127,10 @@ where
             }
             Err(e) => {
                 warn!("Error validating aggregation request: {:?}", e);
+                return Err(Status::new(
+                    Code::Internal,
+                    format!("Failed to validate aggregation request: {}", e),
+                ));
             }
         };
 

--- a/validity/src/proofs_service.rs
+++ b/validity/src/proofs_service.rs
@@ -1,19 +1,17 @@
-use alloy_primitives::hex::FromHex;
-use alloy_primitives::FixedBytes;
+use alloy_primitives::{hex::FromHex, FixedBytes};
 use bincode::Options;
 use tonic::{Code, Request, Response, Status};
 use tracing::{info, warn};
 
-use crate::proof_requester::OPSuccinctProofRequester;
-use crate::OPSuccinctRequest;
-use crate::ProgramConfig;
-use crate::RequestMode;
-use crate::RequesterConfig;
-use crate::ValidityGauge;
-use op_succinct_grpc::proofs::proofs_server::Proofs;
-use op_succinct_grpc::proofs::{AggProofRequest, AggProofResponse, GetMockProofRequest, GetMockProofResponse};
-use op_succinct_host_utils::host::OPSuccinctHost;
-use op_succinct_host_utils::metrics::MetricsGauge;
+use crate::{
+    proof_requester::OPSuccinctProofRequester, OPSuccinctRequest, ProgramConfig, RequestMode,
+    RequesterConfig, ValidityGauge,
+};
+use op_succinct_grpc::proofs::{
+    proofs_server::Proofs, AggProofRequest, AggProofResponse, GetMockProofRequest,
+    GetMockProofResponse,
+};
+use op_succinct_host_utils::{host::OPSuccinctHost, metrics::MetricsGauge};
 use std::{sync::Arc, time::Instant};
 
 pub struct Service<H>
@@ -34,11 +32,7 @@ where
         program_config: ProgramConfig,
         requester_config: RequesterConfig,
     ) -> Self {
-        Self {
-            proof_requester,
-            program_config,
-            requester_config,
-        }
+        Self { proof_requester, program_config, requester_config }
     }
 
     // Limit the L1 block number to the safe head if it is greater than the requested end block
@@ -120,10 +114,7 @@ where
                 l2_chain_id = self.requester_config.l2_chain_id,
                 "No consecutive span proof range found for request"
             );
-            return Err(Status::new(
-                Code::NotFound,
-                "No consecutive span proof range found",
-            ));
+            return Err(Status::new(Code::NotFound, "No consecutive span proof range found"));
         }
 
         // Set the requested_end_block to the last block from the range proofs
@@ -131,11 +122,7 @@ where
 
         // Prepare the request and query the proof requester
         let op_request = OPSuccinctRequest::new_agg_request(
-            if self.requester_config.mock {
-                RequestMode::Mock
-            } else {
-                RequestMode::Real
-            },
+            if self.requester_config.mock { RequestMode::Mock } else { RequestMode::Real },
             req.last_proven_block as i64,
             end_block,
             self.program_config.commitments.range_vkey_commitment,
@@ -185,11 +172,10 @@ where
 
         let reply: AggProofResponse;
         if self.proof_requester.mock {
-            let proof = self
-                .proof_requester
-                .generate_mock_agg_proof(&op_request, stdin)
-                .await
-                .map_err(|e| Status::internal(format!("Failed to generate mock proof: {}", e)))?;
+            let proof =
+                self.proof_requester.generate_mock_agg_proof(&op_request, stdin).await.map_err(
+                    |e| Status::internal(format!("Failed to generate mock proof: {}", e)),
+                )?;
 
             // If it's a compressed proof, we need to serialize the entire struct with bincode.
             let proof_bytes = bincode::DefaultOptions::new()
@@ -204,13 +190,12 @@ where
                 ..op_request.clone()
             };
 
-            // Create an aggregation proof request to cover the range with the checkpointed L1 block hash.
-            let last_id = self
-                .proof_requester
-                .db_client
-                .insert_request(&proved_op_request)
-                .await
-                .map_err(|e| Status::internal(format!("Failed to save request to DB: {}", e)))?;
+            // Create an aggregation proof request to cover the range with the checkpointed L1 block
+            // hash.
+            let last_id =
+                self.proof_requester.db_client.insert_request(&proved_op_request).await.map_err(
+                    |e| Status::internal(format!("Failed to save request to DB: {}", e)),
+                )?;
 
             if last_id > 0 {
                 // Convert the last ID to FixedBytes32
@@ -225,9 +210,7 @@ where
                     proof_request_id: alloy_primitives::Bytes::from(last_id).into(),
                 };
             } else {
-                return Err(Status::internal(
-                    "No AGG proof request inserted in the Database",
-                ));
+                return Err(Status::internal("No AGG proof request inserted in the Database"));
             }
         } else {
             let proof_id = self
@@ -262,9 +245,7 @@ where
             .map_err(|e| Status::not_found(format!("Mock proof not found: {}", e)))?;
 
         // Return the mock proof in the response
-        let response = GetMockProofResponse {
-            proof: mock_proof.into(),
-        };
+        let response = GetMockProofResponse { proof: mock_proof.into() };
 
         Ok(Response::new(response))
     }

--- a/validity/src/proposer.rs
+++ b/validity/src/proposer.rs
@@ -603,27 +603,7 @@ where
             .await?;
 
         if let Some(unreq_agg_request) = unreq_agg_request {
-            // Validate the aggregation proof request
-            match self.proof_requester.validate_aggregation_request(&unreq_agg_request).await {
-                Ok(true) => {
-                    info!(
-                        "Aggregation request validated successfully: start_block={}, end_block={}",
-                        unreq_agg_request.start_block, unreq_agg_request.end_block
-                    );
-                    return Ok(Some(unreq_agg_request));
-                }
-                Ok(false) => {
-                    debug!(
-                        "Aggregation request validation failed, moving to range proofs: start_block={}, end_block={}",
-                        unreq_agg_request.start_block, unreq_agg_request.end_block
-                    );
-                    // Validation failed, continue to try fetching range proofs
-                }
-                Err(e) => {
-                    warn!("Error validating aggregation request: {:?}. Moving to range proofs.", e);
-                    // Error during validation, continue to try fetching range proofs
-                }
-            }
+            return Ok(Some(unreq_agg_request));
         }
 
         let unreq_range_request = self

--- a/validity/src/proposer.rs
+++ b/validity/src/proposer.rs
@@ -604,7 +604,7 @@ where
 
         if let Some(unreq_agg_request) = unreq_agg_request {
             // Validate the aggregation proof request
-            match self.validate_aggregation_request(&unreq_agg_request).await {
+            match self.proof_requester.validate_aggregation_request(&unreq_agg_request).await {
                 Ok(true) => {
                     info!(
                         "Aggregation request validated successfully: start_block={}, end_block={}",
@@ -642,107 +642,6 @@ where
         }
 
         Ok(None)
-    }
-
-    /// Validates an aggregation proof request by checking that:
-    /// 1. The expected range proofs exist and are complete
-    /// 2. There are no gaps between consecutive range proofs
-    /// 3. There are no duplicate/overlapping range proofs
-    /// 4. The range proofs cover the entire block range
-    async fn validate_aggregation_request(&self, agg_request: &OPSuccinctRequest) -> Result<bool> {
-        debug!(
-            "Validating aggregation proof request: start_block={}, end_block={}",
-            agg_request.start_block, agg_request.end_block
-        );
-
-        // Fetch all completed range proofs within the aggregation range
-        let range_proofs = self
-            .driver_config
-            .driver_db_client
-            .get_consecutive_complete_range_proofs(
-                agg_request.start_block,
-                agg_request.end_block,
-                &self.program_config.commitments,
-                agg_request.l1_chain_id,
-                agg_request.l2_chain_id,
-            )
-            .await?;
-
-        // Log all constituent range proofs
-        debug!(
-            "Found {} range proofs for aggregation request (start={}, end={})",
-            range_proofs.len(),
-            agg_request.start_block,
-            agg_request.end_block
-        );
-        for (i, proof) in range_proofs.iter().enumerate() {
-            debug!(
-                "Range proof {}: start_block={}, end_block={}",
-                i, proof.start_block, proof.end_block
-            );
-        }
-
-        // If no range proofs found, validation fails
-        if range_proofs.is_empty() {
-            debug!("No range proofs found for aggregation request - not ready yet");
-            return Ok(false);
-        }
-
-        // Check that first proof starts at or before the aggregation start block
-        if range_proofs[0].start_block > agg_request.start_block {
-            debug!(
-                "First range proof starts at {} but aggregation starts at {} - missing initial proofs",
-                range_proofs[0].start_block, agg_request.start_block
-            );
-            return Ok(false);
-        }
-
-        // Check that last proof ends at or after the aggregation end block
-        let last_proof = &range_proofs[range_proofs.len() - 1];
-        if last_proof.end_block < agg_request.end_block {
-            debug!(
-                "Last range proof ends at {} but aggregation ends at {} - missing final proofs",
-                last_proof.end_block, agg_request.end_block
-            );
-            return Ok(false);
-        }
-
-        // Check for gaps and duplicates between consecutive proofs
-        for i in 1..range_proofs.len() {
-            let prev_proof = &range_proofs[i - 1];
-            let curr_proof = &range_proofs[i];
-
-            // Check for gap
-            if prev_proof.end_block + 1 != curr_proof.start_block {
-                debug!(
-                    "Gap detected: proof {} ends at {} but proof {} starts at {}",
-                    i - 1,
-                    prev_proof.end_block,
-                    i,
-                    curr_proof.start_block
-                );
-                return Ok(false);
-            }
-
-            // Check for overlap (duplicate blocks)
-            if prev_proof.end_block >= curr_proof.start_block {
-                debug!(
-                    "Overlap detected: proof {} ends at {} but proof {} starts at {}",
-                    i - 1,
-                    prev_proof.end_block,
-                    i,
-                    curr_proof.start_block
-                );
-                return Ok(false);
-            }
-        }
-
-        // All validation checks passed
-        debug!(
-            "Aggregation request validated successfully with {} consecutive range proofs",
-            range_proofs.len()
-        );
-        Ok(true)
     }
 
     /// Relay all completed aggregation proofs to the contract.

--- a/validity/src/proposer.rs
+++ b/validity/src/proposer.rs
@@ -6,9 +6,9 @@ use alloy_provider::{network::ReceiptResponse, Provider};
 use alloy_sol_types::SolValue;
 use anyhow::{anyhow, Context, Result};
 use futures_util::{stream, StreamExt, TryStreamExt};
-use op_succinct_grpc::proofs::proofs_server::ProofsServer;
 use op_succinct_client_utils::{boot::hash_rollup_config, types::u32_to_u8};
 use op_succinct_elfs::AGGREGATION_ELF;
+use op_succinct_grpc::proofs::proofs_server::ProofsServer;
 use op_succinct_host_utils::{
     fetcher::OPSuccinctDataFetcher, host::OPSuccinctHost, metrics::MetricsGauge,
     DisputeGameFactory::DisputeGameFactoryInstance as DisputeGameFactoryContract,
@@ -603,7 +603,27 @@ where
             .await?;
 
         if let Some(unreq_agg_request) = unreq_agg_request {
-            return Ok(Some(unreq_agg_request));
+            // Validate the aggregation proof request
+            match self.validate_aggregation_request(&unreq_agg_request).await {
+                Ok(true) => {
+                    info!(
+                        "Aggregation request validated successfully: start_block={}, end_block={}",
+                        unreq_agg_request.start_block, unreq_agg_request.end_block
+                    );
+                    return Ok(Some(unreq_agg_request));
+                }
+                Ok(false) => {
+                    debug!(
+                        "Aggregation request validation failed, moving to range proofs: start_block={}, end_block={}",
+                        unreq_agg_request.start_block, unreq_agg_request.end_block
+                    );
+                    // Validation failed, continue to try fetching range proofs
+                }
+                Err(e) => {
+                    warn!("Error validating aggregation request: {:?}. Moving to range proofs.", e);
+                    // Error during validation, continue to try fetching range proofs
+                }
+            }
         }
 
         let unreq_range_request = self
@@ -622,6 +642,107 @@ where
         }
 
         Ok(None)
+    }
+
+    /// Validates an aggregation proof request by checking that:
+    /// 1. The expected range proofs exist and are complete
+    /// 2. There are no gaps between consecutive range proofs
+    /// 3. There are no duplicate/overlapping range proofs
+    /// 4. The range proofs cover the entire block range
+    async fn validate_aggregation_request(&self, agg_request: &OPSuccinctRequest) -> Result<bool> {
+        debug!(
+            "Validating aggregation proof request: start_block={}, end_block={}",
+            agg_request.start_block, agg_request.end_block
+        );
+
+        // Fetch all completed range proofs within the aggregation range
+        let range_proofs = self
+            .driver_config
+            .driver_db_client
+            .get_consecutive_complete_range_proofs(
+                agg_request.start_block,
+                agg_request.end_block,
+                &self.program_config.commitments,
+                agg_request.l1_chain_id,
+                agg_request.l2_chain_id,
+            )
+            .await?;
+
+        // Log all constituent range proofs
+        debug!(
+            "Found {} range proofs for aggregation request (start={}, end={})",
+            range_proofs.len(),
+            agg_request.start_block,
+            agg_request.end_block
+        );
+        for (i, proof) in range_proofs.iter().enumerate() {
+            debug!(
+                "Range proof {}: start_block={}, end_block={}",
+                i, proof.start_block, proof.end_block
+            );
+        }
+
+        // If no range proofs found, validation fails
+        if range_proofs.is_empty() {
+            debug!("No range proofs found for aggregation request - not ready yet");
+            return Ok(false);
+        }
+
+        // Check that first proof starts at or before the aggregation start block
+        if range_proofs[0].start_block > agg_request.start_block {
+            debug!(
+                "First range proof starts at {} but aggregation starts at {} - missing initial proofs",
+                range_proofs[0].start_block, agg_request.start_block
+            );
+            return Ok(false);
+        }
+
+        // Check that last proof ends at or after the aggregation end block
+        let last_proof = &range_proofs[range_proofs.len() - 1];
+        if last_proof.end_block < agg_request.end_block {
+            debug!(
+                "Last range proof ends at {} but aggregation ends at {} - missing final proofs",
+                last_proof.end_block, agg_request.end_block
+            );
+            return Ok(false);
+        }
+
+        // Check for gaps and duplicates between consecutive proofs
+        for i in 1..range_proofs.len() {
+            let prev_proof = &range_proofs[i - 1];
+            let curr_proof = &range_proofs[i];
+
+            // Check for gap
+            if prev_proof.end_block + 1 != curr_proof.start_block {
+                debug!(
+                    "Gap detected: proof {} ends at {} but proof {} starts at {}",
+                    i - 1,
+                    prev_proof.end_block,
+                    i,
+                    curr_proof.start_block
+                );
+                return Ok(false);
+            }
+
+            // Check for overlap (duplicate blocks)
+            if prev_proof.end_block >= curr_proof.start_block {
+                debug!(
+                    "Overlap detected: proof {} ends at {} but proof {} starts at {}",
+                    i - 1,
+                    prev_proof.end_block,
+                    i,
+                    curr_proof.start_block
+                );
+                return Ok(false);
+            }
+        }
+
+        // All validation checks passed
+        debug!(
+            "Aggregation request validated successfully with {} consecutive range proofs",
+            range_proofs.len()
+        );
+        Ok(true)
     }
 
     /// Relay all completed aggregation proofs to the contract.
@@ -1106,11 +1227,8 @@ where
         ValidityGauge::init_all();
 
         // Parse the url for the gRPC server.
-        let addr = self
-            .requester_config
-            .grpc_addr
-            .parse()
-            .context("Failed to parse gRPC address")?;
+        let addr =
+            self.requester_config.grpc_addr.parse().context("Failed to parse gRPC address")?;
         info!("Starting Agglayer gRPC server on {}", addr);
         // Start the gRPC server
         tokio::spawn(


### PR DESCRIPTION
This pull request introduces several changes across multiple files in the `validity` module, focusing on improving code readability, adding validation logic, and streamlining formatting. The most significant updates include the addition of a new validation method for aggregation proof requests, refactoring code for better readability, and minor formatting adjustments.

### Validation Logic Enhancements:
* Added `validate_aggregation_request` method in `validity/src/proof_requester.rs` to ensure aggregation proof requests meet specific criteria, such as no gaps, overlaps, or missing range proofs. This method logs detailed validation steps and returns a boolean indicating success or failure.
* Integrated the new validation logic into `validity/src/proofs_service.rs`, replacing the previous range proof validation mechanism. Errors are now handled more explicitly with appropriate gRPC status codes.

### Code Formatting Improvements:
* Refactored struct initialization in `validity/src/proofs_service.rs` for consistency and readability.
* Simplified inline conditional expressions and error handling across multiple files, including `validity/src/proofs_service.rs` and `validity/src/proposer.rs`. [[1]](diffhunk://#diff-c798629bafaa232f99d4d598cfa95024714c8b26d7815e0b677f7f4582be2731L188-R191) [[2]](diffhunk://#diff-c798629bafaa232f99d4d598cfa95024714c8b26d7815e0b677f7f4582be2731L207-R211) [[3]](diffhunk://#diff-a7c75e1cb220fca984617eb40cfcdfdf43dd162561395ab061c7dcb99a1b1af1L1109-R1110)

### Logging Enhancements:
* Replaced `warn` logging with `debug` in several files to provide more granular insights during debugging while maintaining higher-level warnings for critical issues. [[1]](diffhunk://#diff-bda9efed9f31be96c3131a9b892164eb6b9e79841c8007274c425207a0d43f8bL16-R17) [[2]](diffhunk://#diff-c798629bafaa232f99d4d598cfa95024714c8b26d7815e0b677f7f4582be2731L1-R14)

### Dependency Updates:
* Adjusted import statements to consolidate and optimize dependencies in `validity/src/env.rs`, `validity/src/proof_requester.rs`, and `validity/src/proofs_service.rs`. [[1]](diffhunk://#diff-9457bce61520b88fd84d0a3acbf405daf9044c14b276512d42a3088572d150e2R4-L8) [[2]](diffhunk://#diff-bda9efed9f31be96c3131a9b892164eb6b9e79841c8007274c425207a0d43f8bR6) [[3]](diffhunk://#diff-c798629bafaa232f99d4d598cfa95024714c8b26d7815e0b677f7f4582be2731L1-R14)

These changes collectively improve the robustness, readability, and maintainability of the codebase.

Supersedes #17 